### PR TITLE
Update default local.py and fix tuple err in default template loader

### DIFF
--- a/dceu2019/src/dceu2019/settings/__init__.py
+++ b/dceu2019/src/dceu2019/settings/__init__.py
@@ -8,15 +8,16 @@ try:
     from .local import *
 except ImportError:
     sys.stderr.write(
-        "Could not find settings.local, creating a default one. Please "
-        "customize it with your SECRET_KEY, DATABASES etc. and start again.\n"
+        "Could not find dceu2019/src/dceu2019/settings/local.py, creating a "
+        "default one. Please customize it with your SECRET_KEY, DATABASES etc. "
+        "and start again.\n"
     )
     default = (
         """# Using development settings, replace in production!\n"""
         """from .dev import *  # noqa\n"""
         """\n"""
         """SECRET_KEY = "{secret_key}"\n"""
-        """DATABASES = DATABASES = {{\n"""
+        """DATABASES = {{\n"""
         """    "default": {{\n"""
         """        "ENGINE": "django.db.backends.sqlite3",\n"""
         """        "NAME": str(BASE_DIR.parent.parent / "db.sqlite3"),\n"""

--- a/dceu2019/src/dceu2019/settings/production.py
+++ b/dceu2019/src/dceu2019/settings/production.py
@@ -24,10 +24,10 @@ CELERY_RESULT_BACKEND = ""
 
 # There is only one entry... but whatevs :)
 for _TEMPLATE in TEMPLATES:
-    _TEMPLATE['OPTIONS'].setdefault('loaders', (
+    _TEMPLATE['OPTIONS'].setdefault('loaders', [
             'django.template.loaders.filesystem.Loader',
             'django.template.loaders.app_directories.Loader',
-        )
+        ]
     )
     _TEMPLATE['OPTIONS']['loaders'].prepend('django.template.loaders.cached.Loader')
 


### PR DESCRIPTION
Testing `master` in production caused some errs.