### PR TITLE
Code of Conduct

### DIFF
--- a/hugo_site/content/conduct.md
+++ b/hugo_site/content/conduct.md
@@ -12,7 +12,7 @@ The organisers will introduce a Code of Conduct team that will be primarily resp
 
 The team can be reached on [conduct@djangocon.eu](mailto:conduct@djangocon.eu).
 
-We adapted this CoC from DjangoCon Europe 2018, with some own additions and some inspiraton from other events. A big thank you to their CoC team, especially for the awesome guidelines how to handle reports, which we have adopted unedited.
+We adapted this CoC from DjangoCon Europe 2018, with some own additions and some inspiraton from other events. A big thank you to their CoC team, especially for the awesome response guidelines, which we have adopted unedited.
 
 ## Why do we have a Code of Conduct?
 

--- a/hugo_site/content/conduct.md
+++ b/hugo_site/content/conduct.md
@@ -16,52 +16,52 @@ The team can be reached on conduct@djangocon.eu.
 
 Our goals with having this Code of Conduct are:
 
-    - Helping everyone feel safe and included. Attendees may have had poor experiences in other events, or can be first-timers. We want to set the expectation that harassment and other unpleasant behaviour are not acceptable. So people who do have an unpleasant experience, know that’s neither the norm nor acceptable to us as a community.
-    - Helping to build trust that if an incident is reported, we will not respond with victim blaming, and that we will proceed with a thorough investigation. Even, for example, if the incident concerns someone in a position of power.
-    - Informing everyone of the expected behaviour. We are a diverse community, and having a Code of Conduct makes the expectations of everybody’s behaviour explicit and transparent.
-    - Having a framework for report handling. The Code of Conduct is the basis for dealing with a report, assessing whether the CoC was violated, and what action should be taken.
+* Helping everyone feel safe and included. Attendees may have had poor experiences in other events, or can be first-timers. We want to set the expectation that harassment and other unpleasant behaviour are not acceptable. So people who do have an unpleasant experience, know that’s neither the norm nor acceptable to us as a community.
+* Helping to build trust that if an incident is reported, we will not respond with victim blaming, and that we will proceed with a thorough investigation. Even, for example, if the incident concerns someone in a position of power.
+* Informing everyone of the expected behaviour. We are a diverse community, and having a Code of Conduct makes the expectations of everybody’s behaviour explicit and transparent.
+* Having a framework for report handling. The Code of Conduct is the basis for dealing with a report, assessing whether the CoC was violated, and what action should be taken.
 
 # Our Code of Conduct
 
 We ask each attendant to keep the community in mind and do their best to foster a positive environment for everyone.
 Behavior that contributes to a positive environment includes
 
-    - Being kind and considerate to others.
-    - Behaving professionally
-    - Using welcoming and inclusive language
-    - Being respectful of differing viewpoints and experiences
-    - Gracefully accepting constructive criticism
-    - Being supportive towards newcomers
+* Being kind and considerate to others.
+* Behaving professionally
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Being supportive towards newcomers
 
 We are dedicated to providing a harassment-free conference experience for everyone, regardless of race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
 
-    - We do not tolerate harassment of conference participants in any form. This includes offensive comments related to the categories above, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, violent threats or language, inappropriate physical contact, and unwelcome sexual attention. Advocating for, or encouraging, any of the above behaviour is also not acceptable.
-    - Sexual language and imagery are not appropriate for any venue to which the CoC applies.
-    - Some people may not wish to be filmed or photographed - respect their wishes, take extra care when publishing pictures and provide a way to request them to be taken down.
-    - Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive and unwelcoming to those around you. Excessive swearing and offensive jokes are not appropriate for DjangoCon Europe.
-    - The Django community has earned a reputation of being welcoming to beginners and we would like to keep it that way. Condescending behavior towards people of different knowledge levels is unacceptable.
-    - No one owes you any form of interaction or explanation why they don't want contact. If someone asks you to leave them alone, accept and respect it without any further discussion, even if you think it is unwarranted.
+* We do not tolerate harassment of conference participants in any form. This includes offensive comments related to the categories above, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, violent threats or language, inappropriate physical contact, and unwelcome sexual attention. Advocating for, or encouraging, any of the above behaviour is also not acceptable.
+* Sexual language and imagery are not appropriate for any venue to which the CoC applies.
+* Some people may not wish to be filmed or photographed - respect their wishes, take extra care when publishing pictures and provide a way to request them to be taken down.
+* Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive and unwelcoming to those around you. Excessive swearing and offensive jokes are not appropriate for DjangoCon Europe.
+* The Django community has earned a reputation of being welcoming to beginners and we would like to keep it that way. Condescending behavior towards people of different knowledge levels is unacceptable.
+* No one owes you any form of interaction or explanation why they don't want contact. If someone asks you to leave them alone, accept and respect it without any further discussion, even if you think it is unwarranted.
 
 # Where does the Code of Conduct apply?
 
 This Code of Conduct applies to all conference related spaces. That includes, but is not limited to:
 
-    - The conference venue(s)
-    - The conference hotel(s)
-    - Any conference related social activities
-    - Slack channels, tweets with the conference hashtag, and other online media
-    - The Code of Conduct does not exclusively apply to events on the conference agenda. For example, if after a scheduled social event you go to a bar with a group of fellow participants, and someone harasses you there, we would still treat that as a CoC violation.
+* The conference venue(s)
+* The conference hotel(s)
+* Any conference related social activities
+* Slack channels, tweets with the conference hashtag, and other online media
+* The Code of Conduct does not exclusively apply to events on the conference agenda. For example, if after a scheduled social event you go to a bar with a group of fellow participants, and someone harasses you there, we would still treat that as a CoC violation.
 
 # What can happen if the CoC is violated?
 
 In case of a Code of Conduct violation, some of the most common actions organisers may take are:
 
-    - Demanding that a participant stops their behaviour.
-    - Demanding that a participant prevents further contact with certain other participants.
-    - Not publishing the video of a conference talk.
-    - Cancelling a conference talk.
-    - Removing a participant from the conference, without refund.
-    - The action taken is at the discretion of the Code of Conduct team. Participants are expected to comply immediately, and further action may be taken in case a participant does not comply. A record will be kept of all incidents.
+* Demanding that a participant stops their behaviour.
+* Demanding that a participant prevents further contact with certain other participants.
+* Not publishing the video of a conference talk.
+* Cancelling a conference talk.
+* Removing a participant from the conference, without refund.
+* The action taken is at the discretion of the Code of Conduct team. Participants are expected to comply immediately, and further action may be taken in case a participant does not comply. A record will be kept of all incidents.
 
 # Where to report incidents
 
@@ -83,13 +83,13 @@ If you are not sure whether the situation was a Code of Conduct violation, or wh
 
 In your report please include, when possible:
 
-    - Your contact info (so we can get in touch with you)
-    - Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.
-    - When and where the incident occurred. Please be as specific as possible.
-    - Your account of what occurred. If there is a written record (e.g. tweets or slack messages) please include screenshots, or otherwise a link.
-    - Any extra context you believe existed for the incident.
-    - If you believe this incident is ongoing.
-    - Any other information you believe we should have.
+* Your contact info (so we can get in touch with you)
+* Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.
+* When and where the incident occurred. Please be as specific as possible.
+* Your account of what occurred. If there is a written record (e.g. tweets or slack messages) please include screenshots, or otherwise a link.
+* Any extra context you believe existed for the incident.
+* If you believe this incident is ongoing.
+* Any other information you believe we should have.
 
 If you don’t have some of this information, or not at this time, please still make the report anyways.
 

--- a/hugo_site/content/conduct.md
+++ b/hugo_site/content/conduct.md
@@ -10,9 +10,9 @@ Everybody who participates in DjangoCon Europe in one way or another is required
 
 The organisers will introduce a Code of Conduct team that will be primarily responsible for handling any incidents. The CoC applies before and throughout the event (including related activities such as social events, and social media). We have also published our response guidelines.
 
-The team can be reached on conduct@djangocon.eu.
+The team can be reached on [conduct@djangocon.eu](mailto:conduct@djangocon.eu).
 
-# Why do we have a Code of Conduct?
+## Why do we have a Code of Conduct?
 
 Our goals with having this Code of Conduct are:
 
@@ -21,7 +21,7 @@ Our goals with having this Code of Conduct are:
 * Informing everyone of the expected behaviour. We are a diverse community, and having a Code of Conduct makes the expectations of everybody’s behaviour explicit and transparent.
 * Having a framework for report handling. The Code of Conduct is the basis for dealing with a report, assessing whether the CoC was violated, and what action should be taken.
 
-# Our Code of Conduct
+## Our Code of Conduct
 
 We ask each attendant to keep the community in mind and do their best to foster a positive environment for everyone.
 Behavior that contributes to a positive environment includes
@@ -42,7 +42,7 @@ We are dedicated to providing a harassment-free conference experience for everyo
 * The Django community has earned a reputation of being welcoming to beginners and we would like to keep it that way. Condescending behavior towards people of different knowledge levels is unacceptable.
 * No one owes you any form of interaction or explanation why they don't want contact. If someone asks you to leave them alone, accept and respect it without any further discussion, even if you think it is unwarranted.
 
-# Where does the Code of Conduct apply?
+## Where does the Code of Conduct apply?
 
 This Code of Conduct applies to all conference related spaces. That includes, but is not limited to:
 
@@ -52,7 +52,7 @@ This Code of Conduct applies to all conference related spaces. That includes, bu
 * Slack channels, tweets with the conference hashtag, and other online media
 * The Code of Conduct does not exclusively apply to events on the conference agenda. For example, if after a scheduled social event you go to a bar with a group of fellow participants, and someone harasses you there, we would still treat that as a CoC violation.
 
-# What can happen if the CoC is violated?
+## What can happen if the CoC is violated?
 
 In case of a Code of Conduct violation, some of the most common actions organisers may take are:
 
@@ -63,7 +63,7 @@ In case of a Code of Conduct violation, some of the most common actions organise
 * Removing a participant from the conference, without refund.
 * The action taken is at the discretion of the Code of Conduct team. Participants are expected to comply immediately, and further action may be taken in case a participant does not comply. A record will be kept of all incidents.
 
-# Where to report incidents
+## Where to report incidents
 
 If a Code of Conduct incident happens to you, or witness it happening to someone else, please contact the CoC team immediately either in person, or by sending an email to conduct@djangocon.eu..
 Your report will be treated confidential and only discussed within the CoC team.
@@ -75,7 +75,7 @@ If you prefer to speak to a male you can email
 
 The team members will be introduced in person at the conference. You can approach any of them at any time to discuss an incident or concern. You can also ask any other staff to help you find them at the conference.
 
-# Guidelines for reporting incidents
+## Guidelines for reporting incidents
 
 Please do not feel like you may be a burden to us by reporting incidents. Even if you happen to report multiple incidents during the conference. We rather consider reports an opportunity for us to act: by knowing about an incident, we can act on it, and often prevent it from continuing or repeating. But if we don’t know, we can’t take action.
 
@@ -97,13 +97,13 @@ If you feel unsafe reporting in person, you may choose someone to represent you.
 
 When handling a report, we follow specific guidelines.
 
-# Emergencies
+## Emergencies
 If you’re currently afraid of your physical safety or are in danger, contact local law enforcement in Denmark:
 
 Emergency (Fire, Medical, Police): 112
 Police directly: 114
 
-# Other assistance
+## Other assistance
 Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. However, we will not contact security or law enforcement without your consent, except when not doing so would create significant danger for other participants.
 
 We value your attendance, and look forward to seeing you at DjangoCon Europe.

--- a/hugo_site/content/conduct.md
+++ b/hugo_site/content/conduct.md
@@ -6,7 +6,102 @@ draft: false
 
 # Code of Conduct
 
-This conference will have a Code of Conduct. The team working on it can be reached on
-[conduct@djangocon.eu](mailto:conduct@djangocon.eu).
+Everybody who participates in DjangoCon Europe in one way or another is required to conform to this Code of Conduct (CoC). This includes attendees, speakers, sponsors, organisers and volunteers.
 
-Please check back in a few days, as it is being reviewed. Inputs are welcome.
+The organisers will introduce a Code of Conduct team that will be primarily responsible for handling any incidents. The CoC applies before and throughout the event (including related activities such as social events, and social media). We have also published our response guidelines.
+
+# Why do we have a Code of Conduct?
+
+Our goals with having this Code of Conduct are:
+
+    - Helping everyone feel safe and included. Attendees may have had poor experiences in other events, or can be first-timers. We want to set the expectation that harassment and other unpleasant behaviour are not acceptable. So people who do have an unpleasant experience, know that’s neither the norm nor acceptable to us as a community.
+    - Helping to build trust that if an incident is reported, we will not respond with victim blaming, and that we will proceed with a thorough investigation. Even, for example, if the incident concerns someone in a position of power.
+    - Informing everyone of the expected behaviour. We are a diverse community, and having a Code of Conduct makes the expectations of everybody’s behaviour explicit and transparent.
+    - Having a framework for report handling. The Code of Conduct is the basis for dealing with a report, assessing whether the CoC was violated, and what action should be taken.
+
+# Our Code of Conduct
+
+We ask each attendant to keep the community in mind and do their best to foster a positive environment for everyone.
+Behavior that contributes to a positive environment includes
+
+    - Being kind and considerate to others.
+    - Behaving professionally
+    - Using welcoming and inclusive language
+    - Being respectful of differing viewpoints and experiences
+    - Gracefully accepting constructive criticism
+    - Being supportive towards newcomers
+
+We are dedicated to providing a harassment-free conference experience for everyone, regardless of race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+
+    - We do not tolerate harassment of conference participants in any form. This includes offensive comments related to the categories above, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, violent threats or language, inappropriate physical contact, and unwelcome sexual attention. Advocating for, or encouraging, any of the above behaviour is also not acceptable.
+    - Sexual language and imagery are not appropriate for any venue to which the CoC applies.
+    - Some people may not wish to be filmed or photographed - respect their wishes, take extra care when publishing pictures and provide a way to request them to be taken down.
+    - Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive and unwelcoming to those around you. Excessive swearing and offensive jokes are not appropriate for DjangoCon Europe.
+    - The Django community has earned a reputation of being welcoming to beginners and we would like to keep it that way. Condescending behavior towards people of different knowledge levels is unacceptable.
+    - No one owes you any form of interaction or explanation why they don't want contact. If someone asks you to leave them alone, accept and respect it without any further discussion, even if you think it is unwarranted.
+
+# Where does the Code of Conduct apply?
+
+This Code of Conduct applies to all conference related spaces. That includes, but is not limited to:
+
+    - The conference venue(s)
+    - The conference hotel(s)
+    - Any conference related social activities
+    - Slack channels, tweets with the conference hashtag, and other online media
+    - The Code of Conduct does not exclusively apply to events on the conference agenda. For example, if after a scheduled social event you go to a bar with a group of fellow participants, and someone harasses you there, we would still treat that as a CoC violation.
+
+# What can happen if the CoC is violated?
+
+In case of a Code of Conduct violation, some of the most common actions organisers may take are:
+
+    - Demanding that a participant stops their behaviour.
+    - Demanding that a participant prevents further contact with certain other participants.
+    - Not publishing the video of a conference talk.
+    - Cancelling a conference talk.
+    - Removing a participant from the conference, without refund.
+    - The action taken is at the discretion of the Code of Conduct team. Participants are expected to comply immediately, and further action may be taken in case a participant does not comply. A record will be kept of all incidents.
+
+# Where to report incidents
+
+If a Code of Conduct incident happens to you, or witness it happening to someone else, please contact the CoC team immediately either in person, or by sending an email to conduct@djangocon.eu..
+Your report will be treated confidential and only discussed within the CoC team.
+We will publish a phone number to call closer to the event.
+
+Our Code of Conduct team consists of ...
+If you prefer to speak to a female you can email sarah@triplesec.tech
+If you prefer to speak to a male you can email
+
+The team members will be introduced in person at the conference. You can approach any of them at any time to discuss an incident or concern. You can also ask any other staff to help you find them at the conference.
+
+# Guidelines for reporting incidents
+
+Please do not feel like you may be a burden to us by reporting incidents. Even if you happen to report multiple incidents during the conference. We rather consider reports an opportunity for us to act: by knowing about an incident, we can act on it, and often prevent it from continuing or repeating. But if we don’t know, we can’t take action.
+
+If you are not sure whether the situation was a Code of Conduct violation, or whether it applied to that particular space, we encourage you to still report it. We would much rather have a few extra reports where we decide to take no action, rather than miss a report of an actual violation. We do not look negatively on you if we find the incident is not a violation. And knowing about incidents that are not violations, or happen outside our spaces, can also help us to improve the Code of Conduct or the processes surrounding it.
+
+In your report please include, when possible:
+
+    - Your contact info (so we can get in touch with you)
+    - Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.
+    - When and where the incident occurred. Please be as specific as possible.
+    - Your account of what occurred. If there is a written record (e.g. tweets or slack messages) please include screenshots, or otherwise a link.
+    - Any extra context you believe existed for the incident.
+    - If you believe this incident is ongoing.
+    - Any other information you believe we should have.
+
+If you don’t have some of this information, or not at this time, please still make the report anyways.
+
+If you feel unsafe reporting in person, you may choose someone to represent you. In this case, we’d need their contact information, but we’d ask you to make clear that this person represents you.
+
+When handling a report, we follow specific guidelines.
+
+# Emergencies
+If you’re currently afraid of your physical safety or are in danger, contact local law enforcement in Denmark:
+
+Emergency (Fire, Medical, Police): 112
+Police directly: 114
+
+# Other assistance
+Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. However, we will not contact security or law enforcement without your consent, except when not doing so would create significant danger for other participants.
+
+We value your attendance, and look forward to seeing you at DjangoCon Europe.

--- a/hugo_site/content/conduct.md
+++ b/hugo_site/content/conduct.md
@@ -10,6 +10,8 @@ Everybody who participates in DjangoCon Europe in one way or another is required
 
 The organisers will introduce a Code of Conduct team that will be primarily responsible for handling any incidents. The CoC applies before and throughout the event (including related activities such as social events, and social media). We have also published our response guidelines.
 
+The team can be reached on conduct@djangocon.eu.
+
 # Why do we have a Code of Conduct?
 
 Our goals with having this Code of Conduct are:

--- a/hugo_site/content/conduct.md
+++ b/hugo_site/content/conduct.md
@@ -67,7 +67,7 @@ In case of a Code of Conduct violation, some of the most common actions organise
 
 ## Where to report incidents
 
-If a Code of Conduct incident happens to you, or witness it happening to someone else, please contact the CoC team immediately either in person, or by sending an email to [conduct@djangocon.eu](mailto:conduct@djangocon.eu)
+If a Code of Conduct incident happens to you, or witness it happening to someone else, please contact the CoC team immediately either in person, or by sending an email to [conduct@djangocon.eu](mailto:conduct@djangocon.eu).
 
 Your report will be treated confidentially and only discussed within the CoC team.
 
@@ -75,12 +75,12 @@ We will publish a phone number to call closer to the event.
 
 Our Code of Conduct team consists of:
 
- * Elvis Camilo
- * Jessica Upani
- * Sarah Braun
- * Víðir Valberg Guðmundsson
+ * Elvis Camilo: [evscamilo@gmail.com](mailto:evscamilo@gmail.com)
+ * Jessica Upani: [nabbygirl@gmail.com](nabbygirl@gmail.com)
+ * Sarah Braun: [sarah@triplesec.tech](mailto:sarah@triplesec.tech)
+ * Víðir Valberg Guðmundsson: [valberg@orn.li](mailto:valberg@orn.li)
 
-If you prefer to speak to a female you can email Sarah: [sarah@triplesec.tech](mailto:sarah@triplesec.tech). If you prefer to speak to a male you can email Elvis: [evscamilo@gmail.com](mailto:evscamilo@gmail.com)
+If you prefer to speak to a female you can email Sarah. If you prefer to speak to a male you can email Elvis.
 
 The team members will be introduced in person at the conference. You can approach any of them at any time to discuss an incident or concern. You can also ask any other staff to help you find them at the conference.
 

--- a/hugo_site/content/conduct.md
+++ b/hugo_site/content/conduct.md
@@ -65,13 +65,20 @@ In case of a Code of Conduct violation, some of the most common actions organise
 
 ## Where to report incidents
 
-If a Code of Conduct incident happens to you, or witness it happening to someone else, please contact the CoC team immediately either in person, or by sending an email to conduct@djangocon.eu..
-Your report will be treated confidential and only discussed within the CoC team.
+If a Code of Conduct incident happens to you, or witness it happening to someone else, please contact the CoC team immediately either in person, or by sending an email to [conduct@djangocon.eu](mailto:conduct@djangocon.eu)
+
+Your report will be treated confidentially and only discussed within the CoC team.
+
 We will publish a phone number to call closer to the event.
 
-Our Code of Conduct team consists of ...
-If you prefer to speak to a female you can email sarah@triplesec.tech
-If you prefer to speak to a male you can email
+Our Code of Conduct team consists of:
+
+ * Elvis Camilo
+ * Jessica Upani
+ * Sarah Braun
+ * Víðir Valberg Guðmundsson
+
+If you prefer to speak to a female you can email Sarah: [sarah@triplesec.tech](mailto:sarah@triplesec.tech). If you prefer to speak to a male you can email Elvis: [evscamilo@gmail.com](mailto:evscamilo@gmail.com)
 
 The team members will be introduced in person at the conference. You can approach any of them at any time to discuss an incident or concern. You can also ask any other staff to help you find them at the conference.
 

--- a/hugo_site/content/conduct.md
+++ b/hugo_site/content/conduct.md
@@ -1,5 +1,5 @@
 ---
-title: "CoC"
+title: "Code of Conduct (CoC)"
 date: 2018-12-18T21:58:22+01:00
 draft: false
 ---
@@ -11,6 +11,8 @@ Everybody who participates in DjangoCon Europe in one way or another is required
 The organisers will introduce a Code of Conduct team that will be primarily responsible for handling any incidents. The CoC applies before and throughout the event (including related activities such as social events, and social media). We have also published our response guidelines.
 
 The team can be reached on [conduct@djangocon.eu](mailto:conduct@djangocon.eu).
+
+We adapted this CoC from DjangoCon Europe 2018, with some own additions and some inspiraton from other events. A big thank you to their CoC team, especially for the awesome guidelines how to handle reports, which we have adopted unedited.
 
 ## Why do we have a Code of Conduct?
 

--- a/hugo_site/content/conduct.md
+++ b/hugo_site/content/conduct.md
@@ -8,7 +8,7 @@ draft: false
 
 Everybody who participates in DjangoCon Europe in one way or another is required to conform to this Code of Conduct (CoC). This includes attendees, speakers, sponsors, organisers and volunteers.
 
-The organisers will introduce a Code of Conduct team that will be primarily responsible for handling any incidents. The CoC applies before and throughout the event (including related activities such as social events, and social media). We have also published our response guidelines.
+The organisers will introduce a Code of Conduct team that will be primarily responsible for handling any incidents. The CoC applies before and throughout the event (including related activities such as social events, and social media). We have also published our [response guidelines](https://2018.djangocon.eu/conduct-response/).
 
 The team can be reached on [conduct@djangocon.eu](mailto:conduct@djangocon.eu).
 

--- a/hugo_site/themes/dceu2019/static/css/style.css
+++ b/hugo_site/themes/dceu2019/static/css/style.css
@@ -6,7 +6,7 @@ body, html
 }
 body {
   font-family: "Courier New", monospace;
-  font-size: 150%;
+  font-size: 140%;
 }
 
 h1 {


### PR DESCRIPTION
Note that the link to the 2018 response guidelines is on purpose. We can clone this text once we have two-level navigation :) see: #18 