### PR TITLE
direct link to the signup page

### DIFF
--- a/hugo_site/content/tickets.md
+++ b/hugo_site/content/tickets.md
@@ -36,4 +36,4 @@ Choose this ticket type if you or your employer want to especially support us do
               ".ticketbutler-iframe"
             )</script></div>
 
-Don't see the above form? There may be a privacy extension for your browser blocking it. We take privacy seriously and are working on a solution. You can disable blocking on this page to see it, sorry sorry sorry... will be back in a few days with a solution.
+Don't see the above form? There may be a privacy extension for your browser blocking it. Link directly to the signup page is the following: [https://djangocon.ticketbutler.io/en/e/2019/](https://djangocon.ticketbutler.io/en/e/2019/).


### PR DESCRIPTION
Added a link to a signup page as fallback for people who can't see the embedded signup form.