### PR TITLE
Add mentioning of company support to CfP

### DIFF
--- a/hugo_site/content/cfp.md
+++ b/hugo_site/content/cfp.md
@@ -49,6 +49,8 @@ As a speaker, you will not need to buy a ticket, since you gain free entrance to
 
 We will not be able to cover travelling and accommodation costs for all speakers, but if you require financial support, please participate in our Opportunity Grant process – speakers will receive special consideration in the selection process.
 
+For companies or employers: Talk content should not be influenced directly by commercial interests, but if your company or employer has supported your process for creating and giving the talk (for instance allowing you to prepare it in working hours), you are *always* welcome to mention this support during a talk. If your employer or company covers travel and accommodation costs, we have a sponsor recognition policy, meaning the company or organization can join as a sponsor. Please get in touch with [sponsors@djangocon.eu](mailto:sponsors@djangocon.eu) to hear more.
+
 ## Guidelines 📏
 
 * Submit your talk in time, no excuses.


### PR DESCRIPTION
@rixx @MarkusH @emilkjer @dawnwages - this is a left-over implementation from a text that described how opportunity grants worked.

I think it's nice to add because it states what I have heard from several people about companies supporting their talks -- and from both sides: Both people who's talks were conditioned by company support, and from organizers and conference goers who have said it's all normal and fine that attribution is giving to a talk.

I find the term "sponsored talk" confusing and misleading, so I avoided this. I know for some people, it just means that a company has covered the costs of the speaker and gets a shout-out.. but it sounds a lot like the contents themselves are sponsored. Just how you would label an ad in a newspaper as "sponsored content" if it looks like a real article :)