### PR TITLE
add grants to menus

### DIFF
--- a/hugo_site/content/cfp.md
+++ b/hugo_site/content/cfp.md
@@ -1,9 +1,9 @@
 ---
-title: "Call for Participation"
+title: "CfP"
 date: 2018-12-16T18:48:39+01:00
 draft: false
 type: "single"
-description: "Our Call for Participation is now open: Please feel invited and invite others."
+description: "Our Call for Participation (CfP) is now open: Please feel invited and invite others."
 menu: main
 weight: 10
 ---

--- a/hugo_site/content/conduct.md
+++ b/hugo_site/content/conduct.md
@@ -1,5 +1,5 @@
 ---
-title: "Code of Conduct"
+title: "Conduct"
 date: 2018-12-18T21:58:22+01:00
 description: Everybody who participates in DjangoCon Europe in one way or another is required to conform to this Code of Conduct (CoC).
 draft: false

--- a/hugo_site/content/grants.md
+++ b/hugo_site/content/grants.md
@@ -1,8 +1,10 @@
 ---
-title: "Opportunity Grants"
+title: "Grants"
 date: 2019-01-09T00:29:12+01:00
 draft: false
 description: DjangoCon Europe 2019 offers grants to attendees and speakers, so that those who might otherwise not be able to attend won't hesitate to participate.
+menu: main
+weight: 30
 ---
 
 # Opportunity Grants


### PR DESCRIPTION
For now, this also shortens CFP and Conduct to make the menu shorter.

We'll make sure to patch this up ASAP so labels don't get too internal lingo-wise.