### PR TITLE
CoC response

### DIFF
--- a/hugo_site/content/conduct-response.md
+++ b/hugo_site/content/conduct-response.md
@@ -1,0 +1,104 @@
+---
+title: "Response Guide"
+date: 2018-01-23T23:52:00+01:00
+description: Guidelines on how to handle reports to possible violations of the Code of Conduct.
+draft: false
+menu:
+  main:
+    parent: "conduct"
+---
+
+## Code of Conduct Response Guide
+
+This is a guide for the organisers and volunteers of DjangoCon Europe on handling [Code of Conduct](/conduct/) (CoC) reports. This guide is mostly aimed at conference staff to help us deal with incidents professionally, and reduce the risk of mistakes. This is especially important because conferences are stressful and involve significant time pressure. However, it's always possible that special circumstances require a deviation from this guide.
+
+Some parts of this guide discuss very severe incidents, like ongoing violence. This is not because these events are common at DjangoCon, but rather because we want to be prepared as well as reasonably possible, for anything from the more common smaller incidents to the most severe cases.
+
+### Guidelines for all organisers and volunteers
+
+DjangoCon Europe has a dedicated Code of Conduct Active Response Ensurers (CARE) team, and this team will generally handle any reports. However, other organisers and volunteers are sometimes the first point of contact, or may observe incidents themselves.
+
+In general, as a representative of the conference, be aware that other participants look toward you for appropriate behaviour within the Code of Conduct.
+
+When you are an organiser or volunteer not on the CARE team, the general guidelines for observing an incident or receiving a report are:
+
+- If you can easily find a member of the CARE team, do that, and let them handle the incident from there on. In that case, you don’t need to do anything else. If you were a witness, the CARE team may ask for more information later.
+- If you can't easily find a CARE team member, write down the basic details of the incident: what happened, who was involved, when and where this happened, whether the incident is ongoing and how we can contact the reporter. If someone is reluctant to provide some of this information, or doesn’t know, do not pressure them.
+- If possible, the reporter can also send a mail to conduct@djangocon.eu. This is helpful, as it gives the CARE team a first-hand written account.
+- In any case, pass the details you noted down to a CARE team member as soon as possible.
+- If requested, try to arrange for an escort by staff or a trusted person, help the reporter contact a friend, or contact local law enforcement. Never pressure any of these action if the reporter does not want this.
+- Do not share any of the information with anyone else.
+
+In speaking to a reporter, be cautious in your wording. Try to be understanding and compassionate, and make them feel heard and taken seriously. However, do not make commitments on whether the conference will see this as a violation, or what action will be taken.
+
+In urgent cases, where it is not possible to contact a CARE team member and you believe immediate action is essential, you may intervene unilaterally. For example, you may consider this:
+
+- When any delay of action will likely bring unacceptable further harm to others. Ongoing aggression or serious harassment are examples of this.
+- If you feel people are in immediate physical danger, it can be appropriate to contact local law enforcement.
+- If you witness a presentation which is clearly in violation of the Code of Conduct repeatedly or very seriously. You might simply say “I’m sorry, this presentation cannot be continued at the present time”. Examples of when this is justified could be significant threats of violence, harassment of others, or continuous sexist jokes. Do not end a presentation in cases like a few inappropriate jokes - in that case do report it to the CARE team.
+
+When possible, even in these cases, consult with another organiser or volunteer if you see one nearby.
+
+### Guidelines for Code of Conduct response team
+
+The Code of Conduct Active Response Ensurers (CARE) are in charge of handling reports until their completion. It is their task to ensure all reports are handled timely and professionally.
+
+Participants look towards the CARE team for appropriate behaviour, even more than other staff, and that makes it essential for their behaviour to remain within the Code of Conduct. Violations by CARE team members can severely erode trust in the Code of Conduct process.
+
+CARE team members almost never act on their own, including tasks like replying to Code of Conduct related e-mails. If it’s not possible to meet with the entire CARE team in time, at least one other team member should be consulted.
+
+#### Receiving a report
+
+Reports are typically received by e-mail, in person, or from another staff member. If the report was received from someone else, it may be best to meet with the original reporter first, depending on how complete the information is. The information the CARE team aims to collect is listed in the Code of Conduct reporting guide, but sometimes not all information is available.
+
+When receiving a report, the CARE team acknowledges receipt as soon as possible, and aims to be understanding and compassionate. However, there should be no commitment on whether this is a violation or which action will be taken.
+
+#### Acting as a team
+
+The CARE team generally works, decides and communicates as a team. If the report indicates that immediate action is required and other CARE team members are not available, any CARE team member may take the action they see appropriate. The same guidelines for unilateral action apply as listed above for other staff members. If possible, it’s still preferred to take action after a brief discussion with at least one other CARE team member, or even any other organiser, rather than acting entirely unilaterally. Formal processes and guidelines must never get in the way of preventing threats to anyone’s safety.
+
+#### Reviewing the report
+
+Based on the report and any other available information, the CARE team will meet to determine, to the best of their ability:
+
+- What happened
+- Whether this event constitutes a Code of Conduct violation
+- Who, if anyone, was the bad actor(s)
+- What the appropriate resolution is
+
+A written record will be kept of each incident and its review. Although that sometimes seems superflous at the time, hectic environments like conferences can make it easy to forget or confuse details later.
+
+As a result of the meeting, the CARE team may come to a conclusion about a resolution, or may conclude that additional information should be obtained. In the latter case, this additional information will be collected as soon as possible. Any conversations as part of this should generally be done by two people from the CARE team.
+
+#### Conflicts of interest
+
+As soon as reasonable, but at the latest at the report review meeting, team members should declare any conflicts of interest. This can mean being friends with one of the involved parties, or anything else that may make it harder to remain neutral.
+
+A conflict of interest does not inherently mean the team member can no longer participate in the process, as that would make it very hard for the team to act on reports involving well-known people in the community. However, if a report concerns someone a team member is very close to, they probably should be not take part in the process. The team will decide together on where to draw this line in individual cases. Where possible, any conversations with offenders should not be done by their friends, as it can be very unpleasant for everyone involved.
+
+#### Resolutions
+
+The most common resolutions the CARE team can decide on are:
+
+- No action (if the team determines no violation occurred).
+- Demanding that a participant stops their behaviour.
+- Demanding that a participant prevents further contact with certain other participants.
+- Not publishing the video of a conference talk.
+- Cancelling a conference talk.
+- Removing a participant from the conference, without refund.
+
+Resolutions are not restricted to these options. Any conversations with bad actors are done by two people from the CARE team, and notes from this conversation will be added to the record of the incident.
+
+When deciding on a resolution, our basic goal is to address the report in an appropriate way, while also looking to prevent or reduce the risk of continuing harm in the future. For example, we may try to distinguish whether a violation occurred intentionally or not, especially in not too severe cases like inappropriate jokes. In intentional cases, or severe behaviour, we'll probably choose for stronger measures. The CARE team can also use behaviour on social media, the conference slack or personal interactions to further build a picture of the person(s) involved.
+
+#### Informing the reporter
+
+After the resolution is complete, the reporter should be informed of the action taken by the CARE team, and the reasoning behind this.
+
+#### Public statements
+
+As a general rule, conference staff should not make any public statements about the behaviour of individual people during or after the conference. An exception to this are situations that happened in a fairly public context, because attendees may otherwise think no action was taken, eroding trust in the Code of Conduct process. The CARE team will decide together whether to make a public statement, and if so, in how much detail. This should not be decided unilaterally.
+
+After each conference, a Code of Conduct transparency report will be published by the CARE team with anonymised information about any violations that might have occurred.
+
+Any public statements should be handled with care not to divulge personally identifying information about anyone affected, and should serve as a means to ensure that attendees will be comfortable reporting harassment and that our community will be kept accountable for supporting and encouraging safe spaces.

--- a/hugo_site/content/conduct.md
+++ b/hugo_site/content/conduct.md
@@ -3,7 +3,9 @@ title: "Conduct"
 date: 2018-12-18T21:58:22+01:00
 description: Everybody who participates in DjangoCon Europe in one way or another is required to conform to this Code of Conduct (CoC).
 draft: false
-menu: main
+menu:
+  main:
+    identifier: "conduct"
 weight: 30
 ---
 
@@ -11,7 +13,7 @@ weight: 30
 
 Everybody who participates in DjangoCon Europe in one way or another is required to conform to this Code of Conduct (CoC). This includes attendees, speakers, sponsors, organisers and volunteers.
 
-The organisers will introduce a Code of Conduct team that will be primarily responsible for handling any incidents. The CoC applies before and throughout the event (including related activities such as social events, and social media). We have also published our [response guidelines](https://2018.djangocon.eu/conduct-response/).
+The organisers will introduce a Code of Conduct team that will be primarily responsible for handling any incidents. The CoC applies before and throughout the event (including related activities such as social events, and social media). We have also published our [response guidelines](/conduct-response/).
 
 The team can be reached on [conduct@djangocon.eu](mailto:conduct@djangocon.eu).
 
@@ -106,7 +108,7 @@ If you don't have some of this information, or not at this time, please still ma
 
 If you feel unsafe reporting in person, you may choose someone to represent you. In this case, we'd need their contact information, but we'd ask you to make clear that this person represents you.
 
-When handling a report, we follow our [response guidelines](https://2018.djangocon.eu/conduct-response/) (link correctly refers to 2018 website, contents will be copied over).
+When handling a report, we follow our [response guidelines](/conduct-response/).
 
 ## Emergencies
 If you're currently afraid of your physical safety or are in danger, contact local law enforcement in Denmark:


### PR DESCRIPTION
Copied CoC response guidelines from DjangoCon 2018 repository. Fixed cross-links with CoC page itself.