### PR TITLE
Enhanced submenu

### DIFF
--- a/hugo_site/themes/dceu2019/assets/style.scss
+++ b/hugo_site/themes/dceu2019/assets/style.scss
@@ -213,8 +213,13 @@ img {
   li {
     list-style-type: none;
 
-    &.active {
+    &.active,
+    &.active:hover {
       background: darken($coral, 10%);
+    }
+
+    &:hover {
+      background: darken($coral, 5%);
     }
   }
 

--- a/hugo_site/themes/dceu2019/layouts/partials/nav.html
+++ b/hugo_site/themes/dceu2019/layouts/partials/nav.html
@@ -20,12 +20,12 @@
     <ul class="header-submenu">
       {{ if and ($currentPage.IsMenuCurrent "main" .) (.HasChildren) }}
         <li class="active">
-          <a href="/{{ $currentPage.Params.menu.main.identifier }}">{{ $currentPage.Params.menu.main.identifier }}</a>
+          <a href="{{ .URL | relURL }}">{{ or .Page.Params.menu.main.alias .Name }}</a>
         </li>
       {{ end }}
       {{ if $currentPage.HasMenuCurrent "main" . }}
         <li>
-          <a href="/{{ $currentPage.Params.menu.main.parent }}">{{ $currentPage.Params.menu.main.parent }}</a>
+          <a href="{{ .Page.URL | relURL  }}">{{ or .Page.Params.menu.main.alias .Page.Name }}</a>
         </li>
       {{ end }}
       {{ if .HasChildren }}


### PR DESCRIPTION
- Added hover effect.
- Simplified code.
- Included possibility of adding an "alias" to the level 1 menu, so that the submenu displays the alias instead of displaying exactly the level 1 name (e.g. "Conduct" is the level 1 menu, but the landing submenu could have a "CoC" alias for simplification)