### PR TITLE
Minor cleanup in menu

### DIFF
--- a/hugo_site/content/cfp.md
+++ b/hugo_site/content/cfp.md
@@ -1,11 +1,12 @@
 ---
-title: "CfP"
+title: "Call for Participation"
 date: 2018-12-16T18:48:39+01:00
 draft: false
 type: "single"
 description: "Our Call for Participation (CfP) is now open: Please feel invited and invite others."
 menu:
   main:
+    name: "CfP"
     parent: "talks"
 ---
 

--- a/hugo_site/content/conduct.md
+++ b/hugo_site/content/conduct.md
@@ -1,9 +1,11 @@
 ---
-title: "Conduct"
+title: "Code of Conduct"
 date: 2018-12-18T21:58:22+01:00
 description: Everybody who participates in DjangoCon Europe in one way or another is required to conform to this Code of Conduct (CoC).
 draft: false
-menu: main
+menu:
+  main:
+    name: "Conduct"
 weight: 30
 ---
 

--- a/hugo_site/content/contact.md
+++ b/hugo_site/content/contact.md
@@ -1,10 +1,11 @@
 ---
-title: "Contact"
+title: "Contact Us"
 date: 2018-12-16T18:59:31+01:00
 description: "Get in touch: We are here to answer your questions."
 draft: false
 menu:
   main:
+    name: "Contact"
     identifier: "contact"
 weight: 50
 ---

--- a/hugo_site/content/information.md
+++ b/hugo_site/content/information.md
@@ -6,6 +6,7 @@ draft: false
 menu:
   main:
     identifier: "information"
+    alias: "General"
 weight: 30
 ---
 

--- a/hugo_site/content/selection-process.md
+++ b/hugo_site/content/selection-process.md
@@ -8,7 +8,7 @@ menu:
 
 ---
 
-# Selection process.
+# Selection process
 
 We are currently defining our selection process and will make this public before
 contacting selected speakers.

--- a/hugo_site/content/visa.md
+++ b/hugo_site/content/visa.md
@@ -5,6 +5,7 @@ description: "Instructions about Visa for Copenhagen for DjangoCon Europe 2019"
 draft: false
 menu:
   main:
+    name: "Visa"
     parent: "information"
 ---
 

--- a/hugo_site/themes/dceu2019/layouts/partials/nav.html
+++ b/hugo_site/themes/dceu2019/layouts/partials/nav.html
@@ -25,7 +25,7 @@
       {{ end }}
       {{ if $currentPage.HasMenuCurrent "main" . }}
         <li>
-          <a href="{{ .Page.URL | relURL  }}">{{ or .Page.Params.menu.main.alias .Page.Name }}</a>
+          <a href="{{ .Page.URL | relURL  }}">{{ or .Page.Params.menu.main.alias .Page.Params.menu.main.name .Page.Name }}</a>
         </li>
       {{ end }}
       {{ if .HasChildren }}


### PR DESCRIPTION
Addresses #68 and other similar cases.

For reference:

- `title` is what shows on browser title and search engines.
- `name` is the short form of title to display on menus.
- `alias` is a variant of `name` for those pages where the submenu link should be different than the menu link (e.g. "Information" is a menu link, but then the page states that it covers general information and that there are other specific information pages, thus, this page can be aliased as "General")