### PR TITLE
Sitemap

### DIFF
--- a/hugo_site/config.toml
+++ b/hugo_site/config.toml
@@ -11,3 +11,8 @@ sectionPagesMenu = "main"
     twittercardimage="twitter_card.png"
     facebookcardimage="facebook_og.png"
     headerimage = "logo.svg"
+
+[sitemap]
+    changefreq = "weekly"
+    filename = "sitemap.xml"
+    priority = 0.5

--- a/hugo_site/themes/dceu2019/assets/style.scss
+++ b/hugo_site/themes/dceu2019/assets/style.scss
@@ -403,18 +403,34 @@ footer {
   background-position: center;
   background-image: url('/img/fin_092.png');
   background-size: 700px;
-  font-size: 0.8rem;
+  font-size: 0.85rem;
 
   section {
     display: flex;
     justify-content: space-between;
     flex-flow: column;
 
+    // &:nth-child(1) {
+    //   background-color: rgba(255, 255, 255, 0.05);
+    //   margin: -1rem;
+    //   margin-bottom: 1rem;
+    //   padding: 1rem;
+    // }
+
     p {
       margin: 1rem;
 
-      &.equal {
+      &.even {
         flex: 1;
+      }
+
+      &.pull-up {
+        @media (max-width: $tablet) {
+          margin-top: -1rem;
+          br:first-child {
+            display: none;
+          }
+        }
       }
     }
 

--- a/hugo_site/themes/dceu2019/assets/style.scss
+++ b/hugo_site/themes/dceu2019/assets/style.scss
@@ -397,25 +397,38 @@ main {
 
 footer {
   color: white;
-  display: flex;
   padding: 1rem;
   margin-top: 1rem;
   background: $purple;
   background-position: center;
   background-image: url('/img/fin_092.png');
   background-size: 700px;
-  justify-content: space-between;
-  align-items: center;
   font-size: 0.8rem;
-  flex-flow: column;
-  text-align: center;
 
-  p {
-    margin: 1rem;
-  }
+  section {
+    display: flex;
+    justify-content: space-between;
+    flex-flow: column;
 
-  @media (min-width: $tablet) {
-    flex-flow: row;
+    p {
+      margin: 1rem;
+
+      &.equal {
+        flex: 1;
+      }
+    }
+
+    @media (min-width: $tablet) {
+      flex-flow: row;
+    }
+
+    &.center {
+      text-align: center;
+    }
+
+    &.middle {
+      align-items: center;
+    }
   }
 }
 

--- a/hugo_site/themes/dceu2019/layouts/partials/footer.html
+++ b/hugo_site/themes/dceu2019/layouts/partials/footer.html
@@ -12,12 +12,37 @@
     </form>
 
   <footer>
-    <p>Generated on {{ dateFormat "Monday, January 2, 2006 - 15:04 MST" now.UTC }}</p>
-
-    <p>
-      <a href="{{ .Site.SitemapAbsURL }}" target="_blank">Sitemap (XML)</a> &middot;
-      Contributions and source code <a href="http://github.com/djangocon/2019.djangocon.eu" target="_blank">on GitHub</a>
-    </p>
+    <section>
+      {{ range .Site.Menus.main }}
+        <p class="equal">
+            <b>{{ .Name }}</b>
+            <br/>
+            {{ if .HasChildren }}
+              <a href="{{ .URL | relURL }}">{{ or .Page.Params.menu.main.alias .Page.Params.menu.main.name .Page.Name }}</a>
+              <br/>
+              {{ range $index, $item := .Children }}
+                <a href="{{ $item.URL | relURL }}">{{ or $item.Page.Params.menu.main.alias $item.Page.Params.menu.main.name $item.Page.Name }}</a>
+                {{ if eq (mod (add $index 1) 3) 0 }}
+                </p><p><br/>
+                {{ else }}
+                <br/>
+                {{ end }}
+              {{ end }}
+            {{ else }}
+              <a href="{{ .URL | relURL }}">{{ .Name }}</a>
+            {{ end }}
+        </p>
+      {{ end }}
+    </section>
+    <section class="center middle">
+      <p>
+        Generated on {{ dateFormat "Monday, January 2, 2006 - 15:04 MST" now.UTC }}<br/>
+      </p>
+      <p>
+        <!-- <a href="{{ .Site.SitemapAbsURL }}" target="_blank">Sitemap <small>(XML)</small></a> &middot; -->
+        Contributions and source code <a href="http://github.com/djangocon/2019.djangocon.eu" target="_blank">on GitHub</a>
+      </p>
+    </section>
   </footer>
 </body>
 </html>

--- a/hugo_site/themes/dceu2019/layouts/partials/footer.html
+++ b/hugo_site/themes/dceu2019/layouts/partials/footer.html
@@ -15,7 +15,7 @@
     <p>Generated on {{ dateFormat "Monday, January 2, 2006 - 15:04 MST" now.UTC }}</p>
 
     <p>
-      <a href="{{ .Site.SitemapAbsURL }}" target="_blank">Sitemap</a> &middot;
+      <a href="{{ .Site.SitemapAbsURL }}" target="_blank">Sitemap (XML)</a> &middot;
       Contributions and source code <a href="http://github.com/djangocon/2019.djangocon.eu" target="_blank">on GitHub</a>
     </p>
   </footer>

--- a/hugo_site/themes/dceu2019/layouts/partials/footer.html
+++ b/hugo_site/themes/dceu2019/layouts/partials/footer.html
@@ -14,19 +14,18 @@
   <footer>
     <section>
       {{ range .Site.Menus.main }}
-        <p class="equal">
+        <p class="even">
             <b>{{ .Name }}</b>
             <br/>
             {{ if .HasChildren }}
               <a href="{{ .URL | relURL }}">{{ or .Page.Params.menu.main.alias .Page.Params.menu.main.name .Page.Name }}</a>
               <br/>
               {{ range $index, $item := .Children }}
-                <a href="{{ $item.URL | relURL }}">{{ or $item.Page.Params.menu.main.alias $item.Page.Params.menu.main.name $item.Page.Name }}</a>
-                {{ if eq (mod (add $index 1) 3) 0 }}
-                </p><p><br/>
-                {{ else }}
-                <br/>
+                {{ if eq (mod (add $index 1) 4) 0 }}
+                  </p><p class="even pull-up"><br/>
                 {{ end }}
+                <a href="{{ $item.URL | relURL }}">{{ or $item.Page.Params.menu.main.alias $item.Page.Params.menu.main.name $item.Page.Name }}</a>
+                <br/>
               {{ end }}
             {{ else }}
               <a href="{{ .URL | relURL }}">{{ .Name }}</a>

--- a/hugo_site/themes/dceu2019/layouts/partials/footer.html
+++ b/hugo_site/themes/dceu2019/layouts/partials/footer.html
@@ -12,10 +12,12 @@
     </form>
 
   <footer>
-    <p>Generated on {{ now }}</p>
-    <p><a href="{{ .Site.SitemapAbsURL }}" target="_blank">Sitemap</a></p>
+    <p>Generated on {{ dateFormat "Monday, January 2, 2006 - 15:04 MST" now.UTC }}</p>
 
-    <p>Contributions and source code: <a href="http://github.com/djangocon/2019.djangocon.eu" target="_blank">http://github.com/djangocon/2019.djangocon.eu</a></p>
+    <p>
+      <a href="{{ .Site.SitemapAbsURL }}" target="_blank">Sitemap</a> &middot;
+      Contributions and source code <a href="http://github.com/djangocon/2019.djangocon.eu" target="_blank">on GitHub</a>
+    </p>
   </footer>
 </body>
 </html>

--- a/hugo_site/themes/dceu2019/layouts/partials/footer.html
+++ b/hugo_site/themes/dceu2019/layouts/partials/footer.html
@@ -13,6 +13,7 @@
 
   <footer>
     <p>Generated on {{ now }}</p>
+    <p><a href="{{ .Site.SitemapAbsURL }}" target="_blank">Sitemap</a></p>
 
     <p>Contributions and source code: <a href="http://github.com/djangocon/2019.djangocon.eu" target="_blank">http://github.com/djangocon/2019.djangocon.eu</a></p>
   </footer>

--- a/hugo_site/themes/dceu2019/layouts/partials/header.html
+++ b/hugo_site/themes/dceu2019/layouts/partials/header.html
@@ -8,6 +8,7 @@
   <meta name="description" content="{{ .Params.description | default .Site.Params.description }}">
 	{{ with .Site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
   {{ $style := resources.Get "style.scss" | resources.ToCSS | resources.Minify }}
+	<link rel="sitemap" href="{{ .Site.SitemapAbsURL }}" />
 	<link rel="stylesheet" href="{{ $style.Permalink }}">
 	<link rel="stylesheet" href="{{ .Site.BaseURL }}css/print.css" media="print">
   <link href="https://fonts.googleapis.com/css?family=Poppins:400,700" rel="stylesheet">


### PR DESCRIPTION
- Added explicit sitemap config with all pages with equal priority and weekly change frequency. These can be changed on a per-page basis, in the page frontmatter, like:
```
sitemap:
  changefreq: "monthly"
```
- Added `link rel=...` to header.
- Added sitemap link to footer (also enhanced the current data in footer for beter integration with additional links, subject to designer's approval)