### PR TITLE
Do not send invite to ticketholders that had their ticket refunded

### DIFF
--- a/dceu2019/src/dceu2019/apps/invoices/management/commands/invite_ticketholders.py
+++ b/dceu2019/src/dceu2019/apps/invoices/management/commands/invite_ticketholders.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        tickets = models.TicketbutlerTicket.objects.all()
+        tickets = models.TicketbutlerTicket.objects.filter(refunded=False)
 
         if not options['reinvite']:
             tickets = tickets.filter(


### PR DESCRIPTION
People didn't use the invites in the first place, so we had to re-invite... then people swapped names, changed ticket types, had refunds... so might have re-invited some people who weren't supposed to 

Wondering what a "dango" is, it sounds like "django" and has its own emoji... :dango: 