### PR TITLE
Use abbreviation for recording source in pretalx

### DIFF
--- a/dceu2019/src/dceu2019/apps/pretalx_utils/management/commands/pretalx_hugoschedule.py
+++ b/dceu2019/src/dceu2019/apps/pretalx_utils/management/commands/pretalx_hugoschedule.py
@@ -163,7 +163,7 @@ class Command(BaseCommand):
 
             if props.youtube_id:
                 props.submission.recording_url = "https://www.youtube.com/watch?v={}".format(props.youtube_id)
-                props.submission.recording_source = "Youtube"
+                props.submission.recording_source = "YT"
                 props.submission.save()
 
             talk_page_file = os.path.join(


### PR DESCRIPTION
Fixes `django.db.utils.DataError: value too long for type character varying(3)`